### PR TITLE
Added nodejs and npm for chrome extension

### DIFF
--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -1,5 +1,6 @@
 FROM codercom/ubuntu-dev-go:latest
 
+RUN sudo apt-get update
 RUN sudo apt-get install -y htop
 LABEL project_root "~/go/src/go.coder.com"
 
@@ -8,8 +9,8 @@ ENV GO111MODULE=off
 
 # Install the latest version of Hugo.
 RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.55.4/hugo_extended_0.55.4_Linux-64bit.deb && \
-    sudo dpkg -i /tmp/hugo.deb && \
-    rm -f /tmp/hugo.deb
+  sudo dpkg -i /tmp/hugo.deb && \
+  rm -f /tmp/hugo.deb
 
 RUN installext peterjausovec.vscode-docker
 

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -18,4 +18,4 @@ RUN sudo apt-get install curl -y
 
 RUN sudo apt-get install software-properties-common -y && \
   curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
-  sudo apt-get install nodejs
+  sudo apt-get install nodejs -y

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -1,7 +1,10 @@
 FROM codercom/ubuntu-dev-go:latest
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y htop
+RUN sudo apt-get update && \
+  sudo apt-get install -y htop && \
+  sudo apt-get install -y software-properties-common && \
+  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
+  sudo apt-get install -y nodejs
 LABEL project_root "~/go/src/go.coder.com"
 
 # Modules break much of Go's tooling.
@@ -13,9 +16,3 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
   rm -f /tmp/hugo.deb
 
 RUN installext peterjausovec.vscode-docker
-
-RUN sudo apt-get install curl -y
-
-RUN sudo apt-get install software-properties-common -y && \
-  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
-  sudo apt-get install nodejs -y

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -12,3 +12,7 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
     rm -f /tmp/hugo.deb
 
 RUN installext peterjausovec.vscode-docker
+
+RUN sudo apt-get install curl python-software-properties && \
+  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
+  sudo apt-get install nodejs

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -2,7 +2,9 @@ FROM codercom/ubuntu-dev-go:latest
 
 RUN sudo apt-get update && \
   sudo apt-get install -y htop && \
-  curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | sudo -E bash -
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \
+    . ~/.nvm/nvm.sh \
+    && nvm install node
 
 LABEL project_root "~/go/src/go.coder.com"
 

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -14,8 +14,8 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
 
 RUN installext peterjausovec.vscode-docker
 
-RUN sudo apt-get install curl
+RUN sudo apt-get install curl -y
 
-RUN sudo apt-get install software-properties-common && \
+RUN sudo apt-get install software-properties-common -y && \
   curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
   sudo apt-get install nodejs

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -2,9 +2,8 @@ FROM codercom/ubuntu-dev-go:latest
 
 RUN sudo apt-get update && \
   sudo apt-get install -y htop && \
-  sudo apt-get install -y software-properties-common && \
-  curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
-  sudo apt-get install -y nodejs
+  curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | sudo -E bash -
+
 LABEL project_root "~/go/src/go.coder.com"
 
 # Modules break much of Go's tooling.

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -1,5 +1,5 @@
 FROM codercom/ubuntu-dev-go:latest
-
+SHELL ["/bin/bash", "-c"]
 RUN sudo apt-get update && \
   sudo apt-get install -y htop && \
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -1,7 +1,7 @@
 FROM codercom/ubuntu-dev-go:latest
 SHELL ["/bin/bash", "-c"]
 RUN sudo apt-get update && \
-  sudo apt-get install -y htop && \
+  sudo apt-get install -y htop
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \
     . ~/.nvm/nvm.sh \
     && nvm install node

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -14,6 +14,8 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
 
 RUN installext peterjausovec.vscode-docker
 
-RUN sudo apt-get install curl python-software-properties && \
+RUN sudo apt-get install curl
+
+RUN sudo apt-get install software-properties-common && \
   curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && \
   sudo apt-get install nodejs


### PR DESCRIPTION
This PR is to solve the issue when trying to develop for the chrome extension through sail.

Currently, when running `sail run roberthmiller/sail`, I am unable to use npm (getting the deps for the chrome extension). This PR is to fix that.

Edit:
Resolves #161 