### PR TITLE
Allow repos as filepaths in sail run

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -16,6 +16,7 @@ import (
 
 type repo struct {
 	*url.URL
+	subdir string
 }
 
 func (r repo) CloneURI() string {
@@ -27,9 +28,7 @@ func (r repo) CloneURI() string {
 }
 
 func (r repo) DockerName() string {
-	return toDockerName(
-		r.trimPath(),
-	)
+	return toDockerName(r.trimPath())
 }
 
 func (r repo) trimPath() string {
@@ -50,7 +49,7 @@ func parseRepo(defaultSchema, defaultHost, defaultOrganization, name string) (re
 		return repo{}, xerrors.Errorf("failed to parse repo path: %w", err)
 	}
 
-	r := repo{u}
+	r := repo{URL: u}
 
 	if r.Scheme == "" {
 		r.Scheme = defaultSchema
@@ -79,8 +78,8 @@ func parseRepo(defaultSchema, defaultHost, defaultOrganization, name string) (re
 	// make sure the path doesn't have a trailing .git
 	r.Path = strings.TrimSuffix(r.Path, ".git")
 
-	// non-existent or invalid path
-	if r.Path == "" || len(strings.Split(r.Path, "/")) != 2 {
+	// non-existent
+	if r.Path == "" {
 		return repo{}, xerrors.Errorf("invalid repo: %s", r.Path)
 	}
 


### PR DESCRIPTION
This is one half of https://github.com/cdr/sail/issues/72

Allows users to specify a location on disk when running a sail repo.

```bash
cd ~/Projects/cdr/code-server
sail run .

cd ~/Projects/cdr
sail run code-server
```

It will error if you specify a folder outside of the project directory

Note: currently specifying a subdirectory of a project will default to opening the base directory of the project.