### PR TITLE
Path compatibility fixes to improve WSL compatibility

### DIFF
--- a/codeserver.go
+++ b/codeserver.go
@@ -24,7 +24,7 @@ import (
 func loadCodeServer(ctx context.Context) (string, error) {
 	start := time.Now()
 
-	const cachePath = "/tmp/sail-code-server-cache/code-server"
+	cachePath := filepath.Join(os.TempDir(), "sail-code-server-cache/code-server")
 
 	// downloadURLPath stores the download URL, so we know whether we should update
 	// the binary.

--- a/config.go
+++ b/config.go
@@ -18,15 +18,14 @@ func resolvePath(homedir string, path string) string {
 		return path
 	}
 
-	list := strings.Split(path, string(filepath.Separator))
-
-	for i, seg := range list {
-		if seg == "~" {
-			list[i] = homedir
-		}
+	// Replace tilde notation in path with homedir.
+	if path == "~" {
+		path = homedir
+	} else if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(homedir, path[2:])
 	}
 
-	return filepath.Join(list...)
+	return filepath.Clean(path)
 }
 
 // config describes the config.toml.

--- a/runner.go
+++ b/runner.go
@@ -236,12 +236,12 @@ func (r *runner) mounts(mounts []mount.Mount, image string) ([]mount.Mount, erro
 	// Mount in VS Code configs.
 	mounts = append(mounts, mount.Mount{
 		Type:   "bind",
-		Source: "~/.config/Code",
+		Source: vscodeConfigDir(),
 		Target: "~/.config/Code",
 	})
 	mounts = append(mounts, mount.Mount{
 		Type:   "bind",
-		Source: "~/.vscode/extensions",
+		Source: vscodeExtensionsDir(),
 		Target: hostExtensionsDir,
 	})
 
@@ -251,8 +251,7 @@ func (r *runner) mounts(mounts []mount.Mount, image string) ([]mount.Mount, erro
 	// socket to the container allows for using the user's existing setup for
 	// ssh authentication instead of having to create a new keys or explicity
 	// pass them in.
-	sshAuthSock, exists := os.LookupEnv("SSH_AUTH_SOCK")
-	if exists {
+	if sshAuthSock, exists := os.LookupEnv("SSH_AUTH_SOCK"); exists {
 		mounts = append(mounts, mount.Mount{
 			Type:   "bind",
 			Source: sshAuthSock,

--- a/vscode.go
+++ b/vscode.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	vsCodeConfigDirEnv     = "VSCODE_CONFIG_DIR"
+	vsCodeExtensionsDirEnv = "VSCODE_EXTENSIONS_DIR"
+)
+
+func vscodeConfigDir() string {
+	if env, ok := os.LookupEnv(vsCodeConfigDirEnv); ok {
+		return os.ExpandEnv(env)
+	}
+
+	path := os.ExpandEnv("$HOME/.config/Code/")
+	if runtime.GOOS == "darwin" {
+		path = os.ExpandEnv("$HOME/Library/Application Support/Code/")
+	}
+	return filepath.Clean(path)
+}
+
+func vscodeExtensionsDir() string {
+	if env, ok := os.LookupEnv(vsCodeExtensionsDirEnv); ok {
+		return os.ExpandEnv(env)
+	}
+
+	path := os.ExpandEnv("$HOME/.vscode/extensions/")
+	return filepath.Clean(path)
+}


### PR DESCRIPTION
Path changes in various locations to help make very basic WSL support possible. Since Docker is running in Windows, it doesn't understand WSL paths so this PR changes any instances of hardcoded paths in a backwards compatible way.

The code-server cache path was changed to use `os.TempDir()` to find the temporary directory rather than a hardcoded `/tmp`.

The code-server config and extension bind mounts were updated to use a function, which uses the old value on Linux and a different value on Darwin. If the `VSCODE_CONFIG_DIR` or `VSCODE_EXTENSIONS_DIR` env vars are present, it will use those instead. This functionality was adapted from sshcode.

There is still a lengthy list of workarounds to make WSL work properly, which are outlined in #210.

### Changes
- Add `VSCODE_CONFIG_DIR` and `VSCODE_EXTENSIONS_DIR` environment
  variables to change the bind mounted code-server and config and
  extensions directories
- Change the default bind mounted code-server config and extension
  paths on darwin
- Change the code-server cache path to use os.TempDir() instead of
  hard-coded /tmp
- Change the resolvePath() function to be compatible with shells