### PR TITLE
Add ubuntu-dev-llvm8 image Dockerfile

### DIFF
--- a/images/main.sh
+++ b/images/main.sh
@@ -4,13 +4,14 @@ set -eu
 BASE_IMAGE=ubuntu-dev
 
 LANG_IMAGES=(
+    ubuntu-dev-gcc8
     ubuntu-dev-go
+    ubuntu-dev-llvm8
+    ubuntu-dev-node12
+    ubuntu-dev-openjdk12
     ubuntu-dev-python2.7
     ubuntu-dev-python3.7
     ubuntu-dev-ruby2.6
-    ubuntu-dev-gcc8
-    ubuntu-dev-node12
-    ubuntu-dev-openjdk12
 )
 
 # Build the base for all images.

--- a/images/ubuntu-dev-llvm8/Dockerfile.comm
+++ b/images/ubuntu-dev-llvm8/Dockerfile.comm
@@ -1,0 +1,49 @@
+# Based Upon:
+# https://github.com/d11wtq/llvm-docker
+#
+# Modifications:
+#
+# - Use LLVM 8 instead of LLVM 3.9.
+# - Change the signing key URL.
+# - Merge `apt-get install` steps into the prior `apt-get update` step.
+# - Check for file already existing when creating symlinks.
+
+FROM %BASE
+
+RUN apt-get update -qq -y && \
+    apt-get install -qq -y wget
+
+# Ubuntu Cosmic LLVM APT repository: http://apt.llvm.org
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+ADD llvm-8.list /etc/apt/sources.list.d/llvm-8.list
+
+RUN apt-get update -qq -y && \
+    apt-get install -qq -y \
+    make \
+    clang-8 \
+    clang-8-doc \
+    clang-format-8 \
+    clang-tools-8 \
+    libc++-8-dev \
+    libc++abi-8-dev \
+    libclang-8-dev \
+    libclang-common-8-dev \
+    libclang1-8 \
+    libfuzzer-8-dev \
+    libllvm-8-ocaml-dev \
+    libllvm8 \
+    libomp-8-dev \
+    lld-8 \
+    lldb-8 \
+    llvm-8 \
+    llvm-8-dev \
+    llvm-8-doc \
+    llvm-8-examples \
+    llvm-8-runtime \
+    llvm-8-tools \
+    python-clang-8
+
+RUN for f in $(find /usr/bin -name '*-8'); do \
+      newname=`echo $f | sed s/-8//`; \
+      [ ! -f $newname ] && ln -s $f $newname || true; \
+    done

--- a/images/ubuntu-dev-llvm8/Dockerfile.lang
+++ b/images/ubuntu-dev-llvm8/Dockerfile.lang
@@ -1,0 +1,3 @@
+FROM %BASE
+
+RUN installext ms-vscode.cpptools

--- a/images/ubuntu-dev-llvm8/llvm-8.list
+++ b/images/ubuntu-dev-llvm8/llvm-8.list
@@ -1,0 +1,2 @@
+deb http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic-8 main
+deb-src http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic-8 main


### PR DESCRIPTION
Adds a new image `ubuntu-dev-llvm8`, which installs key llvm-8 packages from llvm.org's APT repository.

Closes #212.

