### PR TITLE
Add default_organization key to config

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,13 +31,15 @@ func resolvePath(homedir string, path string) string {
 // config describes the config.toml.
 // Changes to this should be accompanied by changes to DefaultConfig.
 type config struct {
-	DefaultImage  string `toml:"default_image"`
-	ProjectRoot   string `toml:"project_root"`
-	DefaultHat    string `toml:"default_hat"`
-	DefaultSchema string `toml:"default_schema"`
-	DefaultHost   string `toml:"default_host"`
+	DefaultImage        string `toml:"default_image"`
+	ProjectRoot         string `toml:"project_root"`
+	DefaultHat          string `toml:"default_hat"`
+	DefaultSchema       string `toml:"default_schema"`
+	DefaultHost         string `toml:"default_host"`
+	DefaultOrganization string `toml:"default_organization"`
 }
 
+// DefaultConfig is the default configuration file string.
 const DefaultConfig = `# sail configuration.
 # default_image is the default Docker image to use if the repository provides none.
 default_image = "codercom/ubuntu-dev"
@@ -54,6 +56,10 @@ default_schema = "ssh"
 
 # default host used to clone repo in sail run if none given
 default_host = "github.com"
+
+# default_oranization lets you configure which username to use on default_host
+# when cloning a repo.
+# default_organization = ""
 `
 
 // metaRoot returns the root path of all metadata stored on the host.

--- a/globalflags.go
+++ b/globalflags.go
@@ -43,7 +43,7 @@ func requireRepo(conf config, prefs schemaPrefs, fl *flag.FlagSet) repo {
 		flog.Fatal("Argument <repo> must be provided.")
 	}
 
-	r, err := parseRepo(defaultSchema(conf, prefs), conf.DefaultHost, repoURI)
+	r, err := parseRepo(defaultSchema(conf, prefs), conf.DefaultHost, conf.DefaultOrganization, repoURI)
 	if err != nil {
 		flog.Fatal("failed to parse repo %q: %v", repoURI, err)
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -51,7 +51,7 @@ func Test_project(t *testing.T) {
 			rb := newRollback()
 			defer rb.run()
 
-			repo, err := parseRepo(test.schema, "github.com", test.repo)
+			repo, err := parseRepo(test.schema, "github.com", "", test.repo)
 			require.NoError(t, err)
 
 			p := &project{

--- a/repo.go
+++ b/repo.go
@@ -44,7 +44,7 @@ func (r repo) BaseName() string {
 // It can be a full url like https://github.com/cdr/sail or ssh://git@github.com/cdr/sail,
 // or just the path like cdr/sail and the host + schema will be inferred.
 // By default the host and the schema will be the provided defaultSchema.
-func parseRepo(defaultSchema, defaultHost, name string) (repo, error) {
+func parseRepo(defaultSchema, defaultHost, defaultOrganization, name string) (repo, error) {
 	u, err := url.Parse(name)
 	if err != nil {
 		return repo{}, xerrors.Errorf("failed to parse repo path: %w", err)
@@ -66,6 +66,11 @@ func parseRepo(defaultSchema, defaultHost, name string) (repo, error) {
 		} else {
 			r.Host = defaultHost
 		}
+	}
+
+	// add the defaultOrganization if the path has no slashes
+	if defaultOrganization != "" && !strings.Contains(r.trimPath(), "/") {
+		r.Path = fmt.Sprintf("%v/%v", defaultOrganization, r.trimPath())
 	}
 
 	// make sure path doesn't have a leading forward slash

--- a/repo_test.go
+++ b/repo_test.go
@@ -9,9 +9,10 @@ import (
 
 func TestParseRepo(t *testing.T) {
 	var tests = []struct {
-		defSchema string
-		defHost   string
-		fullPath  string
+		defSchema       string
+		defHost         string
+		defOrganization string
+		fullPath        string
 
 		expPath     string
 		expHost     string
@@ -23,6 +24,7 @@ func TestParseRepo(t *testing.T) {
 		{
 			"ssh",
 			"github.com",
+			"",
 			"cdr/sail",
 			"cdr/sail",
 			"github.com",
@@ -34,6 +36,7 @@ func TestParseRepo(t *testing.T) {
 		{
 			"http",
 			"github.com",
+			"",
 			"cdr/sail",
 			"cdr/sail",
 			"github.com",
@@ -45,6 +48,7 @@ func TestParseRepo(t *testing.T) {
 		{
 			"https",
 			"github.com",
+			"",
 			"cdr/sail",
 			"cdr/sail",
 			"github.com",
@@ -56,6 +60,7 @@ func TestParseRepo(t *testing.T) {
 		{
 			"https",
 			"github.com",
+			"",
 			"https://github.com/cdr/sail",
 			"cdr/sail",
 			"github.com",
@@ -67,6 +72,7 @@ func TestParseRepo(t *testing.T) {
 		{
 			"ssh",
 			"github.com",
+			"",
 			"git@github.com/cdr/sail.git",
 			"cdr/sail",
 			"github.com",
@@ -78,6 +84,7 @@ func TestParseRepo(t *testing.T) {
 		{
 			"http",
 			"github.com",
+			"",
 			"ssh://git@github.com/cdr/sail",
 			"cdr/sail",
 			"github.com",
@@ -89,6 +96,7 @@ func TestParseRepo(t *testing.T) {
 		{
 			"https",
 			"my.private-git.com",
+			"",
 			"private/repo",
 			"private/repo",
 			"my.private-git.com",
@@ -96,10 +104,22 @@ func TestParseRepo(t *testing.T) {
 			"https",
 			"https://my.private-git.com/private/repo.git",
 		},
+		// ensure default organization works as expected
+		{
+			"ssh",
+			"github.com",
+			"cdr",
+			"sail",
+			"cdr/sail",
+			"github.com",
+			"git",
+			"ssh",
+			"ssh://git@github.com/cdr/sail.git",
+		},
 	}
 
 	for _, test := range tests {
-		repo, err := parseRepo(test.defSchema, test.defHost, test.fullPath)
+		repo, err := parseRepo(test.defSchema, test.defHost, test.defOrganization, test.fullPath)
 		require.NoError(t, err)
 
 		assert.Equal(t, test.expPath, repo.Path, "expected path to be the same")

--- a/sail_helpers_test.go
+++ b/sail_helpers_test.go
@@ -43,7 +43,7 @@ func run(t *testing.T, name, repo, hatPath string, fns ...func(t *testing.T, p *
 
 		conf := mustReadConfig(filepath.Join(metaRoot(), ".sail.toml"))
 
-		repo, err := parseRepo("ssh", "github.com", repo)
+		repo, err := parseRepo("ssh", "github.com", "", repo)
 		require.NoError(t, err)
 
 		p.proj = &project{

--- a/versionmd.go
+++ b/versionmd.go
@@ -9,7 +9,7 @@ import (
 
 var version string
 
-type versioncmd struct {}
+type versioncmd struct{}
 
 func (v *versioncmd) Spec() cli.CommandSpec {
 	return cli.CommandSpec{


### PR DESCRIPTION
Automatically inserts the `default_organization` into repo URLs if there are no slashes in `repo.trimPath()`.

This allows you to do stuff like `sail run sail` if your `default_organization` is set to `cdr`. If an organization name is in the `name` passed to `parseRepo`, it will not prepend the `default_organization`.

If `default_organization = "cdr"`:
```
sail run "sail" => ssh@github.com:cdr/sail.git
sail run "deansheather/test" => ssh@github.com:deansheather/test.git
sail run --https "sail" => https://github.com/cdr/sail.git
sail run "https://bitbucket.com/deansheather/test.git" => https://bitbucket.com/deansheather/test.gi
```

Closes #207.