### PR TITLE
Add on_start label for running a command every time the container starts

### DIFF
--- a/hat-examples/on_start/Dockerfile
+++ b/hat-examples/on_start/Dockerfile
@@ -1,0 +1,6 @@
+FROM codercom/ubuntu-dev
+
+# The command in the on_start label will be run immediately after the
+# project starts. You could use this to reinstall dependencies or
+# perform any other bootstrapping tasks.
+LABEL on_start="touch did_on_start"

--- a/internal/dockutil/exec.go
+++ b/internal/dockutil/exec.go
@@ -11,6 +11,11 @@ func Exec(cntName, cmd string, args ...string) *exec.Cmd {
 	return exec.Command("docker", args...)
 }
 
+func ExecDir(cntName, dir, cmd string, args ...string) *exec.Cmd {
+	args = append([]string{"exec", "-w", dir, "-i", cntName, cmd}, args...)
+	return exec.Command("docker", args...)
+}
+
 func ExecTTY(cntName, dir, cmd string, args ...string) *exec.Cmd {
 	args = append([]string{"exec", "-w", dir, "-it", cntName, cmd}, args...)
 	return exec.Command("docker", args...)

--- a/internal/dockutil/exec.go
+++ b/internal/dockutil/exec.go
@@ -25,6 +25,11 @@ func DetachedExec(cntName, cmd string, args ...string) *exec.Cmd {
 	return exec.Command("docker", args...)
 }
 
+func DetachedExecDir(cntName, dir, cmd string, args ...string) *exec.Cmd {
+	args = append([]string{"exec", "-dw", dir, cntName, cmd}, args...)
+	return exec.Command("docker", args...)
+}
+
 func ExecEnv(cntName string, envs []string, cmd string, args ...string) *exec.Cmd {
 	args = append([]string{"exec", "-e", strings.Join(envs, ","), "-i", cntName, cmd}, args...)
 	return exec.Command("docker", args...)

--- a/site/content/docs/concepts/labels.md
+++ b/site/content/docs/concepts/labels.md
@@ -24,26 +24,26 @@ LABEL project_root "~/go/src/"
 
 Will bind mount the host directory `$project_root/<org>/<repo>` to `~/go/src/<repo>` in the container.
 
-### Run on Open Labels
+### On Start Labels
 
 You can run a command in your sail container after it starts by specifying
-the `on_open` label. If you'd like to run multiple commands on launch, we
-recommend using a `.sh` file as your `on_open` label, as you cannot provide
-multiple `on_open` statements.
+the `on_start` label. If you'd like to run multiple commands on launch, we
+recommend using a `.sh` file as your `on_start` label, as you cannot
+provide multiple `on_start` labels in your image.
 
-The `on_open` label is run detached inside of `/bin/sh` as soon as the
+The `on_start` label is run detached inside of `/bin/bash` as soon as the
 container is started, with the work directory set to your `project_root`
 (see the section above).
 
 For example:
 ```Dockerfile
-LABEL on_open "npm install"
+LABEL on_start "npm install"
 ```
 ```Dockerfile
-LABEL on_open "go get"
+LABEL on_start "go get"
 ```
 ```Dockerfile
-LABEL on_open "./.sail/on_open.sh"
+LABEL on_start "./.sail/on_start.sh"
 ```
 
 Make sure any scripts you make are executable, otherwise sail will fail to

--- a/site/content/docs/concepts/labels.md
+++ b/site/content/docs/concepts/labels.md
@@ -24,6 +24,30 @@ LABEL project_root "~/go/src/"
 
 Will bind mount the host directory `$project_root/<org>/<repo>` to `~/go/src/<repo>` in the container.
 
+### Run on Open Labels
+
+You can run a command in your sail container after it starts by specifying
+the `on_open` label. If you'd like to run multiple commands on launch, we
+recommend using a `.sh` file as your `on_open` label, as you cannot provide
+multiple `on_open` statements.
+
+The `on_open` label is run detached inside of `/bin/sh` as soon as the
+container is started, with the work directory set to your `project_root`
+(see the section above).
+
+For example:
+```Dockerfile
+LABEL on_open "npm install"
+```
+```Dockerfile
+LABEL on_open "go get"
+```
+```Dockerfile
+LABEL on_open "./.sail/on_open.sh"
+```
+
+Make sure any scripts you make are executable, otherwise sail will fail to
+launch.
 
 ### Share Labels
 

--- a/versionmd.go
+++ b/versionmd.go
@@ -9,7 +9,7 @@ import (
 
 var version string
 
-type versioncmd struct {}
+type versioncmd struct{}
 
 func (v *versioncmd) Spec() cli.CommandSpec {
 	return cli.CommandSpec{


### PR DESCRIPTION
Adding the `on_open` label to an image will cause sail to exec that command inside of the container's project directory every time it creates a container.

Added the new label to the documentation.

When this was discussed in #191, the concept was a `.sail/on_open` file rather than a label. This PR uses a label instead of a file, as (in my opinion) a label seems to be a more "sail way" of doing this. As using a label for this functionality hasn't been discussed, **this PR should not be merged until this is discussed**.

Emulating the `.sail/on_open` file is as simple as `LABEL on_open ".sail/on_open"`, and making sure that `.sail/on_open` has a shebang and is executable.

Closes #191.