### PR TITLE
Fix button existance check

### DIFF
--- a/extension/src/content.ts
+++ b/extension/src/content.ts
@@ -39,7 +39,7 @@ const doConnection = (socketUrl: string, projectUrl: string, onMessage: (data: {
 
 const ensureButton = (): void | HTMLElement => {
 	const buttonId = "openinsail";
-	const btn = document.querySelector(buttonId) as HTMLElement;
+	const btn = document.querySelector("#" + buttonId) as HTMLElement;
 	if (btn) {
 		return btn;
 	}


### PR DESCRIPTION
Fixes #222

@kylecarbs document.querySelector with id requires a "#" before the id. https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector