### PR TITLE
[Security] Inject content script only on github and gitlab

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,7 +15,8 @@
 	"content_scripts": [
 		{
 			"matches": [
-				"https://*/*"
+        "https://github.com/*",
+        "https://gitlab.com/*"
 			],
 			"js": [
 				"out/content.js"

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,8 +15,8 @@
 	"content_scripts": [
 		{
 			"matches": [
-        "https://github.com/*",
-        "https://gitlab.com/*"
+				"https://github.com/*",
+				"https://gitlab.com/*"
 			],
 			"js": [
 				"out/content.js"


### PR DESCRIPTION
Fix security issue for users of the sail extension described in these comments: https://github.com/cdr/sail/issues/162#issuecomment-504242822 and https://github.com/cdr/sail/issues/162#issuecomment-504441471. by injecting content script only in github and gitlab. This should only be a temporary fix until a better solution can be found.

Main issue revolves around any page with an input with id `http_project_clone`, a div with class `project-repo-buttons` and a bit of styling being able to sneakily open sail without user consent and knowledge. If you extend this by using a container that does not have code-server installed but rather some malicious package that hosts on the same port, you could instantly close the opened chrome window. That way you can start a container in the background without the user knowing.

Basic demo [here](https://5d0ce182576108e8e2b63f80--sail-testing.netlify.com) - this opens https://github.com/github/personal-website repo without any user interaction.