### PR TITLE
Enabled go modules

### DIFF
--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -15,6 +15,4 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
   sudo dpkg -i /tmp/hugo.deb && \
   rm -f /tmp/hugo.deb
 
-RUN mkdir -p ~/go && sudo chown -R user:user ~/go
-
 RUN installext peterjausovec.vscode-docker

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -8,12 +8,13 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | b
 
 LABEL project_root "~/go/src/go.coder.com"
 
-# Modules break much of Go's tooling.
-ENV GO111MODULE=off
+ENV GO111MODULE=on
 
 # Install the latest version of Hugo.
 RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.55.4/hugo_extended_0.55.4_Linux-64bit.deb && \
   sudo dpkg -i /tmp/hugo.deb && \
   rm -f /tmp/hugo.deb
+
+RUN mkdir -p ~/go && sudo chown -R user:user ~/go
 
 RUN installext peterjausovec.vscode-docker


### PR DESCRIPTION
Enabled go modules and added directory perms.

We might want to add directory perms to the base ubuntu-dev-go image, but I am unsure as of now.

Edit:
Resolves #192 
Resolves #193 