### PR TITLE
Install go binaries by default

### DIFF
--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -18,21 +18,21 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
 
 RUN installext peterjausovec.vscode-docker
 
-# github.com/mdempsky/gocode
-# github.com/uudashr/gopkgs/cmd/gopkgs
-# github.com/ramya-rao-a/go-outline
-# github.com/acroca/go-symbols
-# golang.org/x/tools/cmd/guru
-# golang.org/x/tools/cmd/gorename
-# github.com/go-delve/delve/cmd/dlv
-# github.com/stamblerre/gocode
-# github.com/rogpeppe/godef
-# github.com/sqs/goreturns
-# golang.org/x/lint/golint
-# golang.org/x/tools/cmd/gopls
-# github.com/cweill/gotests/...
-# github.com/fatih/gomodifytags
-# github.com/josharian/impl
-# github.com/davidrjenni/reftools/cmd/fillstruct
-# github.com/haya14busa/goplay/cmd/goplay
-# github.com/godoctor/godoctor
+RUN go get github.com/mdempsky/gocode \
+  github.com/uudashr/gopkgs/cmd/gopkgs \
+  github.com/ramya-rao-a/go-outline \
+  github.com/acroca/go-symbols \
+  golang.org/x/tools/cmd/guru \
+  golang.org/x/tools/cmd/gorename \
+  github.com/go-delve/delve/cmd/dlv \
+  github.com/stamblerre/gocode \
+  github.com/rogpeppe/godef \
+  github.com/sqs/goreturns \ 
+  golang.org/x/lint/golint \
+  golang.org/x/tools/cmd/gopls \
+  github.com/cweill/gotests/... \
+  github.com/fatih/gomodifytags \
+  github.com/josharian/impl \
+  github.com/davidrjenni/reftools/cmd/fillstruct \
+  github.com/haya14busa/goplay/cmd/goplay \
+  github.com/godoctor/godoctor

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -17,3 +17,22 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
   rm -f /tmp/hugo.deb
 
 RUN installext peterjausovec.vscode-docker
+
+# github.com/mdempsky/gocode
+# github.com/uudashr/gopkgs/cmd/gopkgs
+# github.com/ramya-rao-a/go-outline
+# github.com/acroca/go-symbols
+# golang.org/x/tools/cmd/guru
+# golang.org/x/tools/cmd/gorename
+# github.com/go-delve/delve/cmd/dlv
+# github.com/stamblerre/gocode
+# github.com/rogpeppe/godef
+# github.com/sqs/goreturns
+# golang.org/x/lint/golint
+# golang.org/x/tools/cmd/gopls
+# github.com/cweill/gotests/...
+# github.com/fatih/gomodifytags
+# github.com/josharian/impl
+# github.com/davidrjenni/reftools/cmd/fillstruct
+# github.com/haya14busa/goplay/cmd/goplay
+# github.com/godoctor/godoctor


### PR DESCRIPTION
This is an attempt to make vscode-go work upon initial startup on the sail container, but it does not look like this is the proper solution since I had to run `go: install/update binaries` within code-server... 

Any thoughts on this?

cc: @coadler @ammario @deansheather 