### PR TITLE
Fix GOPATH in ubuntu-dev-go image

### DIFF
--- a/images/ubuntu-dev-go/Dockerfile.comm
+++ b/images/ubuntu-dev-go/Dockerfile.comm
@@ -5,6 +5,7 @@
 # 
 # Changed FROM to be compatible with `buildfrom.sh`.
 # Removed WORKDIR.
+# Removed GOPATH.
 
 FROM %BASE
 
@@ -51,7 +52,4 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version
 
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
-RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+ENV PATH /usr/local/go/bin:$PATH

--- a/images/ubuntu-dev-go/Dockerfile.lang
+++ b/images/ubuntu-dev-go/Dockerfile.lang
@@ -1,5 +1,10 @@
 FROM %BASE
 
+# Set and create GOPATH directories.
+ENV GOPATH /home/user/go
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+
 ADD install_go_tools.sh /tmp/
 RUN bash /tmp/install_go_tools.sh
 

--- a/images/ubuntu-dev-go/install_go_tools.sh
+++ b/images/ubuntu-dev-go/install_go_tools.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Taken from https://github.com/Microsoft/vscode-go/wiki/Go-tools-that-the-Go-extension-depends-on
 
+# Taken from https://github.com/Microsoft/vscode-go/wiki/Go-tools-that-the-Go-extension-depends-on
 go get -u -v github.com/ramya-rao-a/go-outline
 go get -u -v github.com/acroca/go-symbols
 go get -u -v github.com/mdempsky/gocode
@@ -20,8 +20,14 @@ go get -u -v github.com/uudashr/gopkgs/cmd/gopkgs
 go get -u -v github.com/davidrjenni/reftools/cmd/fillstruct
 go get -u -v github.com/alecthomas/gometalinter
 
-~/go/bin/gometalinter --install
+go get -u -v github.com/go-delve/delve/cmd/dlv
 
+# gocode-gomod needs to be built manually as the binary is renamed.
+go get -u -v -d github.com/stamblerre/gocode
+go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode
+
+# Install linters for gometalinter.
+$GOPATH/bin/gometalinter --install
 
 # gopls is generally recommended over community tools.
 # It's much faster and more reliable than the other options.


### PR DESCRIPTION
This changes the GOPATH from `/go` to `~/go`. Additionally, this adds a few extra Go tools that vscode-go expects to be installed (so the user won't need to install them manually).

The GOPATH creation stuff was moved from Dockerfile.comm to Dockerfile.lang as it needs to be created as the user the container runs as.

Closes #230.