### PR TITLE
Use code-server v2, download via codesrv-ci.cdr.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-vendor
-bin
+bin/
+vendor/
+sail

--- a/internal/codeserver/download.go
+++ b/internal/codeserver/download.go
@@ -1,53 +1,14 @@
 package codeserver
 
 import (
-	"archive/tar"
-	"compress/gzip"
-	"context"
-	"io"
-	"path/filepath"
-	"strings"
-
-	"github.com/google/go-github/v24/github"
-	"golang.org/x/xerrors"
+	"fmt"
 )
 
-// DownloadURL gets a URL for the latest version of code-server.
-func DownloadURL(ctx context.Context) (string, error) {
-	client := github.NewClient(nil)
-	rel, _, err := client.Repositories.GetLatestRelease(ctx, "cdr", "code-server")
-	if err != nil {
-		return "", xerrors.Errorf("failed to get latest code-server release: %w", err)
-	}
-	for _, v := range rel.Assets {
-		// TODO: fix this jank.
-		if strings.Index(*v.Name, "linux") < 0 {
-			continue
-		}
-		return *v.BrowserDownloadURL, nil
-	}
-	return "", xerrors.New("no released found for platform")
-}
+// CodeServerVersion stores the version of code-server to use.
+// TODO (Dean): move this to build steps
+const CodeServerVersion = "2.1485-vsc1.38.1"
 
-// Extract takes a code-server release tar and writes out the main binary to bin.
-func Extract(ctx context.Context, tarFi io.Reader) (io.Reader, error) {
-	grd, err := gzip.NewReader(tarFi)
-	if err != nil {
-		return nil, xerrors.Errorf("failed to create gzip decoder: %w", err)
-	}
-	defer grd.Close()
-
-	rd := tar.NewReader(grd)
-	for {
-		hdr, err := rd.Next()
-		if err != nil {
-			if err == io.EOF {
-				return nil, xerrors.New("code-server not found")
-			}
-			return nil, err
-		}
-		if filepath.Base(hdr.Name) == "code-server" {
-			return rd, nil
-		}
-	}
+// DownloadURL gets a download URL for the specified version of code-server.
+func DownloadURL(version string) string {
+	return fmt.Sprintf("https://codesrv-ci.cdr.sh/releases/%v/linux-x86_64/code-server", version)
 }

--- a/internal/codeserver/download.go
+++ b/internal/codeserver/download.go
@@ -6,7 +6,7 @@ import (
 
 // CodeServerVersion stores the version of code-server to use.
 // TODO (Dean): move this to build steps
-const CodeServerVersion = "2.1485-vsc1.38.1"
+const CodeServerVersion = "2.1523-vsc1.38.1"
 
 // DownloadURL gets a download URL for the specified version of code-server.
 func DownloadURL(version string) string {

--- a/internal/codeserver/download_test.go
+++ b/internal/codeserver/download_test.go
@@ -1,33 +1,24 @@
 package codeserver
 
 import (
-	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestDownloadURL_Extract(t *testing.T) {
+func TestDownloadURL_FetchAndRun(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
-	defer cancel()
-
-	url, err := DownloadURL(ctx)
-	require.NoError(t, err)
+	url := DownloadURL(CodeServerVersion)
 
 	resp, err := http.Get(url)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-
-	binRd, err := Extract(ctx, resp.Body)
-	require.NoError(t, err)
 
 	if testing.Short() {
 		t.Skipf("downloading code-server can take a while")
@@ -37,7 +28,7 @@ func TestDownloadURL_Extract(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(tmpfi.Name())
 
-	_, err = io.Copy(tmpfi, binRd)
+	_, err = io.Copy(tmpfi, resp.Body)
 	require.NoError(t, err)
 
 	err = os.Chmod(tmpfi.Name(), 0750)

--- a/internal/codeserver/proc.go
+++ b/internal/codeserver/proc.go
@@ -32,8 +32,7 @@ func Port(containerName string) (string, error) {
 	// Example output:
 	// Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
 	// tcp        0      0 localhost:4774          0.0.0.0:*               LISTEN      6/code-server
-	// tcp        0      0 127.0.0.53:domain       0.0.0.0:*               LISTEN      -
-	out, err := dockutil.Exec(containerName, "netstat", "-tpl").CombinedOutput()
+	out, err := dockutil.Exec(containerName, "netstat", "-ntpl").CombinedOutput()
 	if err != nil {
 		return "", xerrors.Errorf("failed to netstat: %s, %w", out, err)
 	}
@@ -43,8 +42,8 @@ func Port(containerName string) (string, error) {
 		if strings.Contains(line, "code-server") {
 			fields := strings.Fields(line)
 			const localAddrIndex = 3
-			localAddrField := fields[localAddrIndex]
-			return strings.TrimLeft(localAddrField, "localhost:"), nil
+			localAddrField := strings.TrimPrefix(fields[localAddrIndex], "127.0.0.1:")
+			return strings.TrimPrefix(localAddrField, "localhost:"), nil
 		}
 	}
 


### PR DESCRIPTION
Currently set to use `2.1485-vsc1.38.1`. Downloaded from `https://codesrv-ci.cdr.sh/releases/$release/linux-x86_64/code-server`. Using `linux-x86_64` shouldn't be a problem (and is what it used before this PR too) as docker on Mac runs in a VM AFAIK.

~~code-server v2 doesn't support `--port 0` yet, and defaults to `8080`. @code-asher should be working on resolving this soon. This shouldn't interfere with using this PR unless you run multiple containers at the same time.~~

This also hardcodes the code-server release identifier into the source, meaning when we release new versions of code-server we need to release a new version of Sail for the benefit of reliability. I think this is a good trade off, considering Sail's mission is to be reliable and reproducible.