### PR TITLE
Fix sail docker and upgrade code-server 

### DIFF
--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -1,8 +1,17 @@
 FROM codercom/ubuntu-dev-go:latest
 SHELL ["/bin/bash", "-c"]
-RUN sudo apt-get upgrade && \
-  sudo apt-get update && \
-  sudo apt-get install -y htop
+
+# Downgrade to ubuntu 18.04 LTS (codercom/ubuntu-dev-go:latest appears to be using a non-LTS version that is end of life support)
+RUN sudo sed -i 's/cosmic/bionic/g' /etc/apt/sources.list
+RUN sudo echo $'Package: * \n\
+Pin: release a=bionic \n\
+Pin-Priority: 1001\n' | sudo tee -a /etc/apt/preferences > /dev/null
+RUN sudo apt-get update -y --allow-downgrades && \
+    sudo apt-get upgrade -y --allow-downgrades && \
+    sudo apt dist-upgrade -y --allow-downgrades
+
+RUN sudo apt-get install -y htop
+
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \
   . ~/.nvm/nvm.sh \
   && nvm install node

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -15,4 +15,6 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
   sudo dpkg -i /tmp/hugo.deb && \
   rm -f /tmp/hugo.deb
 
-#RUN installext ms-azuretools.vscode-docker
+# Fails to install Extension 'ms-azuretools.vscode-docker' not found.
+#    error vscode undefined
+# RUN installext ms-azuretools.vscode-docker

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -14,7 +14,3 @@ LABEL project_root "~/go/src/go.coder.com"
 RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.55.4/hugo_extended_0.55.4_Linux-64bit.deb && \
   sudo dpkg -i /tmp/hugo.deb && \
   rm -f /tmp/hugo.deb
-
-# Fails to install Extension 'ms-azuretools.vscode-docker' not found.
-#    error vscode undefined
-# RUN installext ms-azuretools.vscode-docker

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -1,6 +1,7 @@
 FROM codercom/ubuntu-dev-go:latest
 SHELL ["/bin/bash", "-c"]
-RUN sudo apt-get update && \
+RUN sudo apt-get upgrade && \
+  sudo apt-get update && \
   sudo apt-get install -y htop
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \
   . ~/.nvm/nvm.sh \

--- a/.sail/Dockerfile
+++ b/.sail/Dockerfile
@@ -1,16 +1,8 @@
 FROM codercom/ubuntu-dev-go:latest
 SHELL ["/bin/bash", "-c"]
 
-# Downgrade to ubuntu 18.04 LTS (codercom/ubuntu-dev-go:latest appears to be using a non-LTS version that is end of life support)
-RUN sudo sed -i 's/cosmic/bionic/g' /etc/apt/sources.list
-RUN sudo echo $'Package: * \n\
-Pin: release a=bionic \n\
-Pin-Priority: 1001\n' | sudo tee -a /etc/apt/preferences > /dev/null
-RUN sudo apt-get update -y --allow-downgrades && \
-    sudo apt-get upgrade -y --allow-downgrades && \
-    sudo apt dist-upgrade -y --allow-downgrades
-
-RUN sudo apt-get install -y htop
+RUN sudo apt-get update && \
+    sudo apt-get install -y htop
 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \
   . ~/.nvm/nvm.sh \
@@ -23,4 +15,4 @@ RUN wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.
   sudo dpkg -i /tmp/hugo.deb && \
   rm -f /tmp/hugo.deb
 
-RUN installext peterjausovec.vscode-docker
+#RUN installext ms-azuretools.vscode-docker

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -25,8 +25,8 @@ ENV LC_ALL=en_US.UTF-8
 # install extensions.
 
 RUN wget -O code-server.tgz "https://codesrv-ci.cdr.sh/releases/3.0.1/linux-x86_64.tar.gz" && \
-	tar -C /usr/lib -xzf code-server.tgz && \
-	rm code-server.tgz && \
+    tar -C /usr/lib -xzf code-server.tgz && \
+    rm code-server.tgz && \
     ln -s /usr/lib/code-server-3.0.1-linux-x86_64/code-server /usr/bin/code-server && \
     chmod +x /usr/lib/code-server-3.0.1-linux-x86_64/code-server && \
     chmod +x /usr/bin/code-server

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -23,8 +23,15 @@ ENV LC_ALL=en_US.UTF-8
 # Download in code-server into path. sail will typically override the binary
 # anyways, but it's nice to have this during the build pipepline so we can
 # install extensions.
-RUN wget -O /usr/bin/code-server https://codesrv-ci.cdr.sh/latest-linux && \
-    chmod +x /usr/bin/code-server
 
+# Download and Install code-server: https://github.com/cdr/code-server/releases/tag/3.0.0
+
+RUN wget -O code-server.tgz "https://codesrv-ci.cdr.sh/releases/3.0.1/linux-x86_64.tar.gz"; \
+	tar -C /usr/lib -xzf code-server.tgz; \
+	rm code-server.tgz;
+
+RUN ln -s /usr/lib/code-server-3.0.1-linux-x86_64/code-server /usr/bin/code-server; \
+    chmod +x /usr/lib/code-server-3.0.1-linux-x86_64/code-server; \
+    chmod +x /usr/bin/code-server;
 
 ADD installext /usr/bin/installext

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -24,14 +24,11 @@ ENV LC_ALL=en_US.UTF-8
 # anyways, but it's nice to have this during the build pipepline so we can
 # install extensions.
 
-# Download and Install code-server: https://github.com/cdr/code-server/releases/tag/3.0.0
-
-RUN wget -O code-server.tgz "https://codesrv-ci.cdr.sh/releases/3.0.1/linux-x86_64.tar.gz"; \
-	tar -C /usr/lib -xzf code-server.tgz; \
-	rm code-server.tgz;
-
-RUN ln -s /usr/lib/code-server-3.0.1-linux-x86_64/code-server /usr/bin/code-server; \
-    chmod +x /usr/lib/code-server-3.0.1-linux-x86_64/code-server; \
-    chmod +x /usr/bin/code-server;
+RUN wget -O code-server.tgz "https://codesrv-ci.cdr.sh/releases/3.0.1/linux-x86_64.tar.gz" && \
+	tar -C /usr/lib -xzf code-server.tgz && \
+	rm code-server.tgz && \
+    ln -s /usr/lib/code-server-3.0.1-linux-x86_64/code-server /usr/bin/code-server && \
+    chmod +x /usr/lib/code-server-3.0.1-linux-x86_64/code-server && \
+    chmod +x /usr/bin/code-server
 
 ADD installext /usr/bin/installext

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:cosmic
+FROM buildpack-deps:20.04
 
 RUN apt-get update && apt-get install -y \
     vim \

--- a/images/ubuntu-dev-go/install_go_tools.sh
+++ b/images/ubuntu-dev-go/install_go_tools.sh
@@ -31,5 +31,6 @@ $GOPATH/bin/gometalinter --install
 
 # gopls is generally recommended over community tools.
 # It's much faster and more reliable than the other options.
-go get -u golang.org/x/tools/cmd/gopls
+# FIX: https://github.com/golang/go/issues/36442 by running as described here https://github.com/golang/tools/blob/master/gopls/doc/user.md#installation
+GO111MODULE=on go get golang.org/x/tools/gopls@latest
 

--- a/internal/codeserver/download.go
+++ b/internal/codeserver/download.go
@@ -20,8 +20,8 @@ func DownloadURL(ctx context.Context) (string, error) {
 		return "", xerrors.Errorf("failed to get latest code-server release: %w", err)
 	}
 	for _, v := range rel.Assets {
-		// TODO: fix this jank.
-		if strings.Index(*v.Name, "linux") < 0 {
+		// TODO: fix this jank, detect container architecture instead of hardcoding to x86_64
+		if strings.Index(*v.Name, "linux-x86_64") < 0 {
 			continue
 		}
 		return *v.BrowserDownloadURL, nil

--- a/runner.go
+++ b/runner.go
@@ -165,13 +165,13 @@ func (r *runner) constructCommand(projectDir string) string {
 	//
 	// We start code-server such that extensions installed through the UI are placed in the host's extension dir.
 	cmd := fmt.Sprintf(`set -euxo pipefail || exit 1
-	cd %v
-	# This is necessary in case the .vscode directory wasn't created inside the container, as mounting to the host
-	# extension dir will create it as root.
-	sudo chown user:user ~/.vscode
-	/usr/bin/code-server --host %v --port %v --user-data-dir ~/.config/Code --extensions-dir %v --extra-extensions-dir ~/.vscode/extensions --auth=none \
-	--allow-http 2>&1 | tee %v
-	`, projectDir, containerAddr, containerPort, hostExtensionsDir, containerLogPath)
+cd %v
+# This is necessary in case the .vscode directory wasn't created inside the container, as mounting to the host
+# extension dir will create it as root.
+sudo chown user:user ~/.vscode
+/usr/bin/code-server --host %v --port %v --user-data-dir ~/.config/Code --extensions-dir %v --extra-extensions-dir ~/.vscode/extensions --auth=none \
+--allow-http 2>&1 | tee %v`,
+		projectDir, containerAddr, containerPort, hostExtensionsDir, containerLogPath)
 
 	if r.testCmd != "" {
 		cmd = r.testCmd + "\n exit 1"

--- a/runner.go
+++ b/runner.go
@@ -165,13 +165,14 @@ func (r *runner) constructCommand(projectDir string) string {
 	//
 	// We start code-server such that extensions installed through the UI are placed in the host's extension dir.
 	cmd := fmt.Sprintf(`set -euxo pipefail || exit 1
-cd %v
-# This is necessary in case the .vscode directory wasn't created inside the container, as mounting to the host
-# extension dir will create it as root.
-sudo chown user:user ~/.vscode
-code-server --host %v --port %v \
-	--data-dir ~/.config/Code --extensions-dir %v --extra-extensions-dir ~/.vscode/extensions --allow-http --no-auth 2>&1 | tee %v
-`, projectDir, containerAddr, containerPort, hostExtensionsDir, containerLogPath)
+	cd %v
+	# This is necessary in case the .vscode directory wasn't created inside the container, as mounting to the host
+	# extension dir will create it as root.
+	sudo chown user:user ~/.vscode
+	/usr/bin/code-server --host %v --port %v --user-data-dir ~/.config/Code --extensions-dir %v --extra-extensions-dir ~/.vscode/extensions --auth=none \
+	--allow-http 2>&1 | tee %v
+	`, projectDir, containerAddr, containerPort, hostExtensionsDir, containerLogPath)
+
 	if r.testCmd != "" {
 		cmd = r.testCmd + "\n exit 1"
 	}


### PR DESCRIPTION
- Fixes #250  issues with ubuntu 18.10 base docker image, upgrade to ubuntu 20.04 LTS (will be supported for a good while)
- Fixes #260 Fixes #261  issue with `sail` using latest `code-server` which now supports ARM64 and X86 architectures

It now appears to work
```
$ cd sail/images
# Rebuild base image
$ ./main.sh
# Rebuild golang image
$ ../buildlang.sh ubuntu-dev-go
# Tag for local docker images
$ docker tag ubuntu-dev-go:latest codercom/ubuntu-dev-go:latest
# Rebuild sail and run
$ go install && sail -v run --keep dougnukem/sail
Successfully built 22e42f37c091
Successfully tagged dougnukem_sail:latest
2020-03-10 15:40:03 INFO	using repo image dougnukem_sail
2020-03-10 15:40:03 DEBUG	host home dir: /Users/douglasdaniels
2020-03-10 15:40:03 INFO	writing sail proxy logs to /var/folders/ht/gwk63jw55_b_kpkk3jf599r40000gn/T/sailproxy_dougnukem_sail209919673
2020-03-10 15:40:03 DEBUG	started container
2020-03-10 15:40:04 DEBUG	code-server online
2020-03-10 15:40:04 INFO	please visit http://127.0.0.1:62686
```

# Open Issues
I needed to disable the installation of the docker vs-code extension as it can't be resolved using `code-server` for some reason, it looks like the namespace changed recently (https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker):
```
Installing extensions...
Extension 'ms-azuretools.vscode-docker' not found.
Make sure you use the full extension ID, including the publisher, e.g.: ms-vscode.csharp
error vscode undefined
The command '/bin/bash -c installext 'ms-azuretools.vscode-docker'' returned a non-zero code: 1
2020-03-10 15:39:15 FATAL	failed to build image: failed to build: exit status 1
```