### PR TITLE
FIXES #201 Sail browser extension docker not found error on MacOS

### DIFF
--- a/globalflags.go
+++ b/globalflags.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/fatih/color"
@@ -37,6 +39,15 @@ func (gf *globalFlags) config() config {
 
 // ensureDockerDaemon verifies that Docker is running.
 func (gf *globalFlags) ensureDockerDaemon() {
+	if runtime.GOOS == "darwin" {
+		path := os.Getenv("PATH")
+		localBin := "/usr/local/bin"
+		if !strings.Contains(path, localBin) {
+			sep := fmt.Sprintf("%c", os.PathListSeparator)
+			// Fix for MacOS to include /usr/local/bin where docker is commonly installed which is not included in $PATH when sail is launched by browser that was opened in Finder
+			os.Setenv("PATH", strings.Join([]string{path, localBin}, sep))
+		}
+	}
 	out, err := exec.Command("docker", "info").CombinedOutput()
 	if err != nil {
 		flog.Fatal("failed to run `docker info`: %v\n%s", err, out)

--- a/globalflags.go
+++ b/globalflags.go
@@ -39,6 +39,8 @@ func (gf *globalFlags) config() config {
 
 // ensureDockerDaemon verifies that Docker is running.
 func (gf *globalFlags) ensureDockerDaemon() {
+	// docker is installed in /usr/local/bin on MacOS, but this isn't in
+	// $PATH when launched by a browser that was opened via Finder.
 	if runtime.GOOS == "darwin" {
 		path := os.Getenv("PATH")
 		localBin := "/usr/local/bin"

--- a/globalflags.go
+++ b/globalflags.go
@@ -44,7 +44,6 @@ func (gf *globalFlags) ensureDockerDaemon() {
 		localBin := "/usr/local/bin"
 		if !strings.Contains(path, localBin) {
 			sep := fmt.Sprintf("%c", os.PathListSeparator)
-			// Fix for MacOS to include /usr/local/bin where docker is commonly installed which is not included in $PATH when sail is launched by browser that was opened in Finder
 			os.Setenv("PATH", strings.Join([]string{path, localBin}, sep))
 		}
 	}


### PR DESCRIPTION
FIXES #201 chrome extension: failed to run `docker info`

On MacOS when Chrome is launched from Finder (as opposed to from terminal/shell session) the `$PATH` environment variable does not contain `/usr/local/bin` which is the common location for docker to be installed.

This PR adds in `/usr/local/bin` to be included in the PATH env variable on MacOS `darwin`.

See similar issues with other browser extensions that rely on Go to execute commands on the user's path:

browserpass/browserpass-legacy#13
browserpass/browserpass-legacy#159
